### PR TITLE
Update travis to use containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: cpp
 compiler: gcc
+sudo: false
+addons:
+  apt:
+    packages:
+    - liblog4cxx10-dev 
+    - libboost-program-options-dev 
+    - libboost-filesystem-dev
+    - libboost-date-time-dev
+    - libboost-system-dev
+    - libboost-test-dev
+    - libboost-thread-dev
+    - libzmq3-dev
 install:
-- sudo apt-get update -qq
-- sudo apt-get install -qq liblog4cxx10-dev libboost-program-options-dev libboost-filesystem-dev
-  libboost-date-time-dev libboost-system-dev libboost-test-dev libboost-thread-dev
-  libzmq3-dev
 - pwd
 - ls *
 - mkdir -p build


### PR DESCRIPTION
Updating travis to use containers. This new infrastructure is faster (builds starts within 10sec) and with more resources (RAM + CPU).

The main changes: no sudo so debian packages need to be installed in a different fashion (included).

Details: http://docs.travis-ci.com/user/migrating-from-legacy/
