### PR TITLE
Making frameReceiver build on Mac OSX

### DIFF
--- a/include/gettime.h
+++ b/include/gettime.h
@@ -1,0 +1,43 @@
+/*
+ * gettime.h
+ *
+ *  Created on: 23 Oct 2015
+ *      Author: ulrik
+ */
+
+#ifndef INCLUDE_GETTIME_H_
+#define INCLUDE_GETTIME_H_
+
+#include <time.h>
+#include <sys/time.h>
+
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+// Our own version of clock_gettime or clock_get_time which works for both Linux and Mac OSX
+static inline void gettime(struct timespec *ts, bool monotonic=false) {
+
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+	clock_serv_t cclock;
+	clock_id_t clockid;
+	if (monotonic) clockid = SYSTEM_CLOCK;
+	else clockid = CALENDAR_CLOCK;
+	mach_timespec_t mts;
+	host_get_clock_service(mach_host_self(), clockid, &cclock);
+	clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+	ts->tv_sec = mts.tv_sec;
+	ts->tv_nsec = mts.tv_nsec;
+#else
+	clockid_t clockid;
+	if (monotonic) clockid = CLOCK_MONOTONIC;
+	else clockid = CLOCK_REALTIME;
+	clock_gettime(clockid, ts);
+#endif
+
+}
+
+
+#endif /* INCLUDE_GETTIME_H_ */

--- a/src/IpcReactor.cpp
+++ b/src/IpcReactor.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "IpcReactor.h"
+#include "gettime.h"
 
 using namespace FrameReceiver;
 
@@ -118,7 +119,7 @@ TimeMs IpcReactorTimer::when(void)
 TimeMs IpcReactorTimer::clock_mono_ms(void)
 {
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    gettime(&ts, true);
 
     return (TimeMs)((TimeMs) ts.tv_sec * 1000 + (TimeMs) ts.tv_nsec / 1000000);
 }

--- a/src/PercivalEmulatorFrameDecoder.cpp
+++ b/src/PercivalEmulatorFrameDecoder.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "PercivalEmulatorFrameDecoder.h"
+#include "gettime.h"
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -146,7 +147,7 @@ void PercivalEmulatorFrameDecoder::process_packet_header(size_t bytes_received, 
             current_frame_header_->frame_state = FrameDecoder::FrameReceiveStateIncomplete;
             current_frame_header_->packets_received = 0;
 
-            clock_gettime(CLOCK_REALTIME, reinterpret_cast<struct timespec*>(&(current_frame_header_->frame_start_time)));
+            gettime(reinterpret_cast<struct timespec*>(&(current_frame_header_->frame_start_time)));
 
     	}
     	else
@@ -231,7 +232,7 @@ void PercivalEmulatorFrameDecoder::monitor_buffers(void)
     int frames_timedout = 0;
     struct timespec current_time;
 
-    clock_gettime(CLOCK_REALTIME, &current_time);
+    gettime(&current_time);
 
     // Loop over frame buffers currently in map and check their state
     std::map<uint32_t, int>::iterator buffer_map_iter = frame_buffer_map_.begin();

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -15,14 +15,15 @@ list(REMOVE_ITEM APP_SOURCES ${APP_MAIN_SOURCE})
 # Add test and project source files to executable
 add_executable(frameReceiverTest ${TEST_SOURCES} ${APP_SOURCES})
 
+if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
 # librt required for timing functions
 find_library(REALTIME_LIBRARY 
 		NAMES rt)
+target_link_libraries( frameReceiverTest ${REALTIME_LIBRARY} )
+endif()
 
 # Define libraries to link against
 target_link_libraries(frameReceiverTest 
-		${Boost_LIBRARIES} 
-		${LOG4CXX_LIBRARIES} 
-		${ZEROMQ_LIBRARIES}
-		${REALTIME_LIBRARY})
-		
+		${Boost_LIBRARIES}
+		${LOG4CXX_LIBRARIES}
+		${ZEROMQ_LIBRARIES}) 

--- a/test/unittest/IpcMessageUnitTest.cpp
+++ b/test/unittest/IpcMessageUnitTest.cpp
@@ -11,6 +11,7 @@
 #include <exception>
 
 #include "IpcMessage.h"
+#include "gettime.h"
 
 BOOST_AUTO_TEST_SUITE(IpcMessageUnitTest);
 
@@ -272,7 +273,7 @@ BOOST_AUTO_TEST_CASE( TestIpcMessageCreationSpeed )
 	struct timespec start, end;
 	double deltaT, rate;
 
-	clock_gettime(CLOCK_REALTIME, &start);
+	gettime(&start);
 
 	BOOST_CHECK_NO_THROW(
 		for (int i = 0; i < numLoops; i++)
@@ -283,12 +284,12 @@ BOOST_AUTO_TEST_CASE( TestIpcMessageCreationSpeed )
 		}
 	);
 
-	clock_gettime(CLOCK_REALTIME, &end);
+	gettime(&end);
 	deltaT = timeDiff(&start, &end);
 	rate = (double)numLoops / deltaT;
 	BOOST_TEST_MESSAGE("Created and encoded " << numLoops << " IPC messages in " << timeDiff(&start, &end) << " secs, rate " << rate << " Hz" );
 
-	clock_gettime(CLOCK_REALTIME, &start);
+	gettime(&start);
 
 
 	BOOST_CHECK_NO_THROW(
@@ -307,7 +308,7 @@ BOOST_AUTO_TEST_CASE( TestIpcMessageCreationSpeed )
 		}
 	);
 
-	clock_gettime(CLOCK_REALTIME, &end);
+	gettime(&end);
 	deltaT = timeDiff(&start, &end);
 	rate = (double)numLoops / deltaT;
 	BOOST_TEST_MESSAGE("Created and parsed " << numLoops << " IPC messages from string in " << timeDiff(&start, &end) << " secs, rate " << rate << " Hz");


### PR DESCRIPTION
Mostly just because we can - it has no real usage in the real world - but it's nice to work natively on my laptop during development :smiley: 

Only two minor changes were required to make it build:
- Adding a Linux/Mac compatible gettime function.
- Linking librt only on Linux.

However, the unittest fail in "CreateAndPingRxThread" with a few unpredictable errors:

```
[ulrik@macpro build]$ ./bin/frameReceiverTest --log_level=all -- run_test=FrameReceiverRxThreadUnitTest
Running 1 test case...
Entering test suite "FrameReceiverUnitTests"
Entering test suite "FrameReceiverRxThreadUnitTest"
Entering test case "CreateAndPingRxThread"
Setup test fixture
Tear down test fixture
Bus error: 10
[ulrik@macpro build]$ 
[ulrik@macpro build]$ ./bin/frameReceiverTest --log_level=all --run_test=FrameReceiverRxThreadUnitTest
Running 1 test case...
Entering test suite "FrameReceiverUnitTests"
Entering test suite "FrameReceiverRxThreadUnitTest"
Entering test case "CreateAndPingRxThread"
Setup test fixture
Tear down test fixture
unknown location:0: fatal error in "CreateAndPingRxThread": std::exception: RX channel failed to set receive socket buffer size for port 8989 : No buffer space available
Leaving test case "CreateAndPingRxThread"; testing time: 1730mks
Leaving test suite "FrameReceiverRxThreadUnitTest"
Leaving test suite "FrameReceiverUnitTests"

*** 1 failure detected in test suite "FrameReceiverUnitTests"
Segmentation fault: 11
[ulrik@macpro build]$ 
[ulrik@macpro build]$ ./bin/frameReceiverTest --log_level=all --run_test=FrameReceiverRxThreadUnitTest
Running 1 test case...
Entering test suite "FrameReceiverUnitTests"
Entering test suite "FrameReceiverRxThreadUnitTest"
Entering test case "CreateAndPingRxThread"
Setup test fixture
Tear down test fixture
Segmentation fault: 11
```

Low and behold the frameReceiver application also segfaults with a similar error:

```
[ulrik@macpro build]$ ./bin/frameReceiver -c test_config/fr_test.config -d 2 
0 [0x7fff76698300] DEBUG FrameReceiver null - Debug level set to  2
0 [0x7fff76698300] DEBUG FrameReceiver null - Parsing configuration file test_config/fr_test.config
2015-10-23 22:20:56,030 DEBUG FrameReceiver - log4cxx config file is set to ../config/log4cxx.config
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Setting frame buffer maximum memory size to 840000000
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Setting sensor type to percivalemulator (0)
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Setting RX port(s) to 8000 8001 
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Setting RX interface address to 0.0.0.0
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Setting shared frame buffer name to FrameReceiverBuffer
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Setting incomplete frame timeout to 1000
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Setting number of frames to receive to 0
2015-10-23 22:20:56,030 DEBUG FrameReceiver - Packet diagnostic logging is enabled
2015-10-23 22:20:56,030 INFO  FrameReceiver - Running frame receiver
2015-10-23 22:20:56,030 INFO  FrameReceiver - Created PERCIVAL emulator frame decoder instance
2015-10-23 22:20:56,040 DEBUG FrameReceiver - Initialised frame buffer manager of total size 840000000 with 100 buffers
2015-10-23 22:20:56,040 DEBUG FrameReceiver - Running RX thread service
2015-10-23 22:20:56,041 DEBUG FrameReceiver - RX thread receive buffer size for port 8000 is 196724
2015-10-23 22:20:56,041 ERROR FrameReceiver - Frame receiver run failed: RX channel failed to set receive socket buffer size for port 8000 : No buffer space available
```

I have not yet tracked down where this goes wrong so maybe this PR is not quite ready for merging :smile: 
