### PR TITLE
Added packet info to frame buffer header

### DIFF
--- a/include/PercivalEmulatorFrameDecoder.h
+++ b/include/PercivalEmulatorFrameDecoder.h
@@ -45,12 +45,14 @@ namespace FrameReceiver
         static const size_t num_tail_packets    = 1;
         static const size_t num_subframes       = 2;
         static const size_t num_data_types      = 2;
+        static const size_t frame_info_size     = 22;
 
         typedef struct
         {
             uint32_t frame_number;
             uint32_t frame_state;
             struct timespec frame_start_time;
+            uint8_t  frame_info[frame_info_size];
             uint32_t packets_received;
             uint8_t  packet_state[num_data_types][num_subframes][num_primary_packets + num_tail_packets];
         } FrameHeader;
@@ -84,6 +86,7 @@ namespace FrameReceiver
         uint8_t get_subframe_number(void) const;
         uint16_t get_packet_number(void) const;
         uint32_t get_frame_number(void) const;
+        uint8_t* get_frame_info(void) const;
 
     private:
 

--- a/include/PercivalEmulatorFrameDecoder.h
+++ b/include/PercivalEmulatorFrameDecoder.h
@@ -45,15 +45,15 @@ namespace FrameReceiver
         static const size_t num_tail_packets    = 1;
         static const size_t num_subframes       = 2;
         static const size_t num_data_types      = 2;
-        static const size_t frame_info_size     = 22;
+        static const size_t frame_info_size     = 14;
 
         typedef struct
         {
             uint32_t frame_number;
             uint32_t frame_state;
             struct timespec frame_start_time;
-            uint8_t  frame_info[frame_info_size];
             uint32_t packets_received;
+            uint8_t  frame_info[frame_info_size];
             uint8_t  packet_state[num_data_types][num_subframes][num_primary_packets + num_tail_packets];
         } FrameHeader;
 

--- a/src/PercivalEmulatorFrameDecoder.cpp
+++ b/src/PercivalEmulatorFrameDecoder.cpp
@@ -296,7 +296,7 @@ uint32_t PercivalEmulatorFrameDecoder::get_frame_number(void) const
 
 uint8_t* PercivalEmulatorFrameDecoder::get_frame_info(void) const
 {
-    return (reinterpret_cast<uint8_t*>(raw_packet_header()+14));
+    return (reinterpret_cast<uint8_t*>(raw_packet_header()+8));
 }
 
 uint8_t* PercivalEmulatorFrameDecoder::raw_packet_header(void) const

--- a/src/PercivalEmulatorFrameDecoder.cpp
+++ b/src/PercivalEmulatorFrameDecoder.cpp
@@ -146,7 +146,7 @@ void PercivalEmulatorFrameDecoder::process_packet_header(size_t bytes_received, 
             current_frame_header_->frame_number = current_frame_seen_;
             current_frame_header_->frame_state = FrameDecoder::FrameReceiveStateIncomplete;
             current_frame_header_->packets_received = 0;
-
+            memcpy(current_frame_header_->frame_info, get_frame_info(), frame_info_size);
             gettime(reinterpret_cast<struct timespec*>(&(current_frame_header_->frame_start_time)));
 
     	}
@@ -292,6 +292,11 @@ uint32_t PercivalEmulatorFrameDecoder::get_frame_number(void) const
 {
 	uint32_t frame_number_raw = *(reinterpret_cast<uint32_t*>(raw_packet_header()+2));
     return ntohl(frame_number_raw);
+}
+
+uint8_t* PercivalEmulatorFrameDecoder::get_frame_info(void) const
+{
+    return (reinterpret_cast<uint8_t*>(raw_packet_header()+14));
 }
 
 uint8_t* PercivalEmulatorFrameDecoder::raw_packet_header(void) const

--- a/tools/python/frame_processor/frame_processor.py
+++ b/tools/python/frame_processor/frame_processor.py
@@ -148,7 +148,8 @@ class FrameProcessor(object):
                       (frame_number, buffer_id, self.frame_decoder.header.frame_number, 
                        self.frame_decoder.header.frame_state, self.frame_decoder.header.frame_start_time.isoformat(),
                        self.frame_decoder.header.packets_received))
-
+        self.logger.debug("Frame info : " + ' '.join("0x{:02x}".format(val) for val in self.frame_decoder.header.frame_info))
+        
         self.frame_decoder.decode_data(buffer_id)
         self.logger.debug("Frame start: " + ' '.join("0x{:04x}".format(val) for val in self.frame_decoder.data.pixels[:32]))
         self.logger.debug("Frame end  : " + ' '.join("0x{:04x}".format(val) for val in self.frame_decoder.data.pixels[-32:]))

--- a/tools/python/frame_processor/percival_emulator_frame_decoder.py
+++ b/tools/python/frame_processor/percival_emulator_frame_decoder.py
@@ -3,7 +3,7 @@ from struct import calcsize, Struct
 
 class PercivalFrameHeader(Struct):
     
-    frame_header_format = '<LLQQL1024BL'
+    frame_header_format = '<LLQQL14B1024B6B'
     
     @classmethod
     def size(cls):       
@@ -19,8 +19,11 @@ class PercivalFrameHeader(Struct):
         self.frame_state = header_vals[1]
         self.frame_start_time = datetime.fromtimestamp(float(header_vals[2]) + float(header_vals[3])/1000000000)
         self.packets_received = header_vals[4]
-        self.packet_state = header_vals[5:-1]
+        self.frame_info = header_vals[5:19]
+        self.packet_state = header_vals[19:-6]
+        self.padding = header_vals[-6:]
         
+
 class PercivalFrameData(Struct):
     
     primary_packet_size = 8192

--- a/tools/python/frame_producer/frame_producer.py
+++ b/tools/python/frame_producer/frame_producer.py
@@ -132,6 +132,8 @@ class FrameProducer(object):
         for frame in range(self.frames):
             
             print "frame: ", frame
+            info_offset = (frame % 16)*16
+            header['Information'] = [range(info_offset, info_offset+14)]
             
             # Construct host & port from lists
             (host, port) = (self.host[frame % index], self.port[frame % index] )


### PR DESCRIPTION
This added the per-packet information field to the frame buffer header in the PERCIVAL emulator instance. Since this field should not change from one packet to another within a given frame, the first packet seen on any frame has its info field copied into the shared memory buffer header, so it is available to downstream processing tasks.

This implements the feature requested in issue #21 
