### PR TITLE
Filewriter support for multiple concurrent instances

### DIFF
--- a/tools/filewriter/FileWriter.h
+++ b/tools/filewriter/FileWriter.h
@@ -36,6 +36,7 @@ public:
     };
 
     explicit FileWriter();
+    FileWriter(size_t num_processes, size_t process_rank);
     virtual ~FileWriter();
 
     void createFile(std::string filename, size_t chunk_align=1024 * 1024);
@@ -53,7 +54,10 @@ private:
     hid_t pixelToHdfType(FileWriter::PixelType pixel) const;
     HDF5Dataset_t& get_hdf5_dataset(const std::string dset_name);
     void extend_dataset(FileWriter::HDF5Dataset_t& dset, size_t frame_no) const;
+    size_t adjustFrameOffset(size_t frame_no) const;
 
+    const hsize_t concurrent_processes_;
+    const hsize_t concurrent_rank_;
     hsize_t start_frame_offset_;
     hid_t hdf5_fileid_;
     std::map<std::string, FileWriter::HDF5Dataset_t> hdf5_datasets_;

--- a/tools/filewriter/FileWriter.h
+++ b/tools/filewriter/FileWriter.h
@@ -17,6 +17,7 @@ using namespace log4cxx;
 // Forward declarations
 class Frame;
 
+
 class FileWriter {
 public:
     enum PixelType { pixel_raw_8bit, pixel_raw_16bit, pixel_float32 };
@@ -43,6 +44,9 @@ public:
     void writeSubFrames(const Frame& frame);
     void closeFile();
 
+    size_t getFrameOffset(size_t frame_no) const;
+    void setStartFrameOffset(size_t frame_no);
+
 private:
     FileWriter(const FileWriter& src); // prevent copying one of these
     LoggerPtr log_;
@@ -50,6 +54,7 @@ private:
     HDF5Dataset_t& get_hdf5_dataset(const std::string dset_name);
     void extend_dataset(FileWriter::HDF5Dataset_t& dset, size_t frame_no) const;
 
+    hsize_t start_frame_offset_;
     hid_t hdf5_fileid_;
     std::map<std::string, FileWriter::HDF5Dataset_t> hdf5_datasets_;
 };

--- a/tools/filewriter/FileWriterTest.cpp
+++ b/tools/filewriter/FileWriterTest.cpp
@@ -228,6 +228,49 @@ BOOST_AUTO_TEST_CASE( FileWriterAdjustHugeOffset )
     BOOST_REQUIRE_NO_THROW(fw.closeFile());
 }
 
+BOOST_AUTO_TEST_CASE( FileWriterSubProcess )
+{
+    // Frame numbers start from 1: 1,2,3,4,5  - but are indexed from 0 in the frames vector.
+    // Process numbers start from 0: 0,1,2 - this process pretends to be process 1.
+
+    FileWriter fw1(3, 1);
+    BOOST_REQUIRE_NO_THROW(fw1.createFile("/tmp/process_1of3.h5"));
+    BOOST_REQUIRE_NO_THROW(fw1.createDataset(dset_def));
+    BOOST_REQUIRE_EQUAL(dset_def.name, frame->get_dataset_name());
+    BOOST_REQUIRE_NO_THROW(fw1.setStartFrameOffset(frames[0]->get_frame_number()));
+
+    // Write frame no. 2 to "data"
+    BOOST_CHECK_EQUAL(frames[1]->get_frame_number(), 2);
+    BOOST_REQUIRE_NO_THROW(fw1.writeFrame(*frames[1]));
+
+    // write frame no. 5 to "data"
+    BOOST_CHECK_EQUAL(frames[4]->get_frame_number(), 5);
+    BOOST_REQUIRE_NO_THROW(fw1.writeFrame(*frames[4]));
+
+    // check the edge case where the frame no. is not supposed to go into this file
+    // write frame no. 4 to "data" and watch it except!
+    BOOST_CHECK_EQUAL(frames[3]->get_frame_number(), 4);
+    BOOST_REQUIRE_THROW(fw1.writeFrame(*frames[3]), std::runtime_error);
+
+    BOOST_REQUIRE_NO_THROW(fw1.closeFile());
+
+    FileWriter fw0(3, 0);
+    BOOST_REQUIRE_NO_THROW(fw0.createFile("/tmp/process_0of3.h5"));
+    BOOST_REQUIRE_NO_THROW(fw0.createDataset(dset_def));
+    BOOST_REQUIRE_EQUAL(dset_def.name, frame->get_dataset_name());
+    BOOST_REQUIRE_NO_THROW(fw0.setStartFrameOffset(frames[0]->get_frame_number()));
+
+    // Write frame no. 1 to "data"
+    BOOST_CHECK_EQUAL(frames[0]->get_frame_number(), 1);
+    BOOST_REQUIRE_NO_THROW(fw0.writeFrame(*frames[0]));
+
+    // write frame no. 4 to "data"
+    BOOST_CHECK_EQUAL(frames[3]->get_frame_number(), 4);
+    BOOST_REQUIRE_NO_THROW(fw0.writeFrame(*frames[3]));
+
+    BOOST_REQUIRE_NO_THROW(fw0.closeFile());
+
+}
 
 BOOST_AUTO_TEST_SUITE_END(); //FileWriterUnitTest
 

--- a/tools/filewriter/FileWriterTest.cpp
+++ b/tools/filewriter/FileWriterTest.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE( FileWriterAdjustHugeOffset )
     std::vector< boost::shared_ptr<Frame> >::iterator it;
     for (it = frames.begin(); it != frames.end(); ++it){
         size_t frame_no = (*it)->get_frame_number();
-        FrameHeader img_header = *((*it)->get_header());
+        PercivalEmulator::FrameHeader img_header = *((*it)->get_header());
         img_header.frame_number = frame_no + huge_offset;
         (*it)->copy_header(&img_header);
         hsize_t offset = fw.getFrameOffset((*it)->get_frame_number());

--- a/tools/filewriter/app.cpp
+++ b/tools/filewriter/app.cpp
@@ -56,7 +56,7 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
         config.add_options()
                 ("logconfig,l",  po::value<string>(),
                     "Set the log4cxx logging configuration file")
-                ("ready,r",       po::value<std::string>()->default_value("tcp://127.0.0.1:5001"),
+                ("ready",       po::value<std::string>()->default_value("tcp://127.0.0.1:5001"),
                     "Ready ZMQ endpoint from frameReceiver")
                 ("release",       po::value<std::string>()->default_value("tcp://127.0.0.1:5002"),
                         "Release frame ZMQ endpoint from frameReceiver")
@@ -66,6 +66,10 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
                     "Set the name of the shared memory frame buffer")
                 ("output,o",     po::value<std::string>(),
                     "Name of HDF5 file to write frames to (default: no file writing)")
+                ("processes,p",  po::value<unsigned int>()->default_value(1),
+                    "Number of concurrent file writer processes"   )
+                ("rank,r",       po::value<unsigned int>()->default_value(0),
+                    "The rank (index number) of the current file writer process in relation to the other concurrent ones")
                 ;
 
         // Group the variables for parsing at the command line and/or from the configuration file
@@ -132,6 +136,16 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
             LOG4CXX_DEBUG(logger, "Writing frames to file: " << vm["output"].as<string>());
         }
 
+        if (vm.count("processes"))
+        {
+            LOG4CXX_DEBUG(logger, "Number of concurrent filewriter processes: " << vm["processes"].as<unsigned int>());
+        }
+
+        if (vm.count("rank"))
+        {
+            LOG4CXX_DEBUG(logger, "This process rank (index): " << vm["rank"].as<unsigned int>());
+        }
+
     }
     catch (po::unknown_option &e)
     {
@@ -189,7 +203,7 @@ int main(int argc, char** argv)
     poll_item.revents = 0;
 
     // The file writer object
-    FileWriter hdfwr;
+    FileWriter hdfwr(vm["processes"].as<unsigned int>(), vm["rank"].as<unsigned int>());
     bool write_file = false;
     if (vm.count("output")) {
         write_file = true;
@@ -306,7 +320,7 @@ int main(int argc, char** argv)
                     //hdfwr.writeFrame(reset_frame);
                     hdfwr.writeSubFrames(reset_frame);
                 }
-                catch (std::range_error& err){
+                catch (std::runtime_error& err){
                 	LOG4CXX_WARN(logger, "Dropping Frame: " << frame.get_frame_number() << " Exception: " << err.what());
                 }
             }

--- a/tools/filewriter/app.cpp
+++ b/tools/filewriter/app.cpp
@@ -296,10 +296,19 @@ int main(int argc, char** argv)
 
             // Write the frame to disk
             if (write_file) {
-                //hdfwr.writeFrame(frame);
-                hdfwr.writeSubFrames(frame);
-                //hdfwr.writeFrame(reset_frame);
-                hdfwr.writeSubFrames(reset_frame);
+                if (notification_count <= 1) {
+                    // The first received frame is used to set a frame number offset
+                    hdfwr.setStartFrameOffset(frame.get_frame_number());
+                }
+                try {
+                    //hdfwr.writeFrame(frame);
+                    hdfwr.writeSubFrames(frame);
+                    //hdfwr.writeFrame(reset_frame);
+                    hdfwr.writeSubFrames(reset_frame);
+                }
+                catch (std::range_error& err){
+                	LOG4CXX_WARN(logger, "Dropping Frame: " << frame.get_frame_number() << " Exception: " << err.what());
+                }
             }
 
         } else

--- a/tools/filewriter/app.cpp
+++ b/tools/filewriter/app.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv)
     // Create a default basic logger configuration, which can be overridden by command-line option later
     BasicConfigurator::configure();
 
-    LoggerPtr logger(Logger::getLogger("FrameNotifier"));
+    LoggerPtr logger(Logger::getLogger("FileWriterApp"));
     po::variables_map vm;
     parse_arguments(argc, argv, vm, logger);
 


### PR DESCRIPTION
The file writer has been extended to: 
- support multiple concurrent instances (CLI interface: --processes and --rank). Fixes #23 
- record a starting offset from the first received frame and subtract this offset when writing frames to the dataset. Fixes #25 
