### PR TITLE
log4cxx: split log4cxx.xml into two files

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_CONFIGS
-  log4cxx.xml
+  fw_log4cxx.xml
+  fr_log4cxx.xml
   fr_test.config
   fr_test_osx.config
   fp_test.config

--- a/config/README.md
+++ b/config/README.md
@@ -6,15 +6,15 @@ This dir contain a number of configuration files to be used by frameReceiver and
 Logging Configuration
 ---------------------
 
-Logging of various messages from the software applications is all done using log4cxx (a C++ port of the log4j 1.x library). This allow using a single configuration file for all parts of the framework: log4cxx.xml
+Logging of various messages from the software applications is all done using log4cxx (a C++ port of the log4j 1.x library). This allow using simple configuration files for all each application.
 
 A sensible default configuration is provided, but it can be adjusted to be more or less verbose, send messages to different files, etc etc. For details of the XML configuration format see: https://wiki.apache.org/logging-log4j/Log4jXmlFormat
 
 The logging configuration will by default write messages to stdout - and the following files will also be produced. Each run will overwrite the previous log file:
 
-Application   | Log type             | Log file                              | Log level
---------------|----------------------|---------------------------------------|-----------
-frameReceiver | Application messages | /tmp/frameReceiver.log                | DEBUG
-frameReceiver | UDP packet info      | /tmp/tmp/frameReceiver_packetDump.log | INFO
-filewriter    | Application messages | /tmp/fileWriter.log                   | DEBUG
+Application   | Config         | Log type             | Log file                              | Log level
+--------------|----------------|----------------------|---------------------------------------|-----------
+frameReceiver | fr_log4cxx.xml | Application messages | /tmp/frameReceiver.log                | DEBUG
+frameReceiver | fr_log4cxx.xml | UDP packet info      | /tmp/tmp/frameReceiver_packetDump.log | INFO
+filewriter    | fw_log4cxx.xml | Application messages | /tmp/fileWriter.log                   | DEBUG
 

--- a/config/fr_log4cxx.xml
+++ b/config/fr_log4cxx.xml
@@ -27,39 +27,11 @@
   </layout>
  </appender>
 
- <appender name="FileWriterAppender" class="org.apache.log4j.FileAppender">
-  <param name="file" value="/tmp/fileWriter.log" />
-  <param name="append" value="false" />
-  <layout class="org.apache.log4j.PatternLayout">
-   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-16c %-5p (%F:%L) - %m%n" />
-  </layout>
- </appender>
- 
-<appender name="syslog" class="org.apache.log4j.net.SyslogAppender">
-  <param name="Facility" value="LOCAL1"/>
-  <param name="SyslogHost" value="localhost:5140"/>
-  <param name="Threshold" value="INFO"/>
-  <layout class="org.apache.log4j.PatternLayout">
-    <param name="ConversionPattern"  value="%d{HH:mm:ss,SSS} %-16c %-5p - %m%n"/>
-  </layout>
-</appender>
-
  <!-- all of the loggers inherit settings from the root -->
  <root>
   <priority value="all" />
   <appender-ref ref="ApplicationConsoleAppender" />
-  <!--   <appender-ref ref="syslog" /> -->
  </root>
-
- <!-- The file writer application logger hierachy -->
- <logger name="FW">
-  <priority value="all" />
-  <appender-ref ref="FileWriterAppender" />
- </logger>
- <logger name="FW.APP"></logger>
- <logger name="FW.SHM"></logger>
- <logger name="FW.Frame"></logger>
- <logger name="FW.FileWriter"></logger>
 
  <!-- The frame receiver application logger hierachy -->
  <logger name="FR">

--- a/config/fr_test.config
+++ b/config/fr_test.config
@@ -1,4 +1,4 @@
-logconfig=../config/log4cxx.xml
+logconfig=../config/fr_log4cxx.xml
 sensortype=percivalemulator
 #maxmem=1073741824
 maxmem=840000000

--- a/config/fr_test_osx.config
+++ b/config/fr_test_osx.config
@@ -1,4 +1,4 @@
-logconfig=../config/log4cxx.xml
+logconfig=../config/fr_log4cxx.xml
 sensortype=percivalemulator
 #maxmem=1073741824
 maxmem=840000000

--- a/config/fw_log4cxx.xml
+++ b/config/fw_log4cxx.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+ <!-- Output the log message to system console -->
+ <appender name="ApplicationConsoleAppender" class="org.apache.log4j.ConsoleAppender">
+  <param name="Target" value="System.out" />
+  <layout class="org.apache.log4j.PatternLayout">
+   <!-- <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-14c %-5p (%F:%L) - %m%n"/> -->
+   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-14c %-5p - %m%n" />
+  </layout>
+ </appender>
+
+ <appender name="FileWriterAppender" class="org.apache.log4j.FileAppender">
+  <param name="file" value="/tmp/fileWriter.log" />
+  <param name="append" value="false" />
+  <layout class="org.apache.log4j.PatternLayout">
+   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-16c %-5p (%F:%L) - %m%n" />
+  </layout>
+ </appender>
+ 
+<!-- 
+<appender name="syslog" class="org.apache.log4j.net.SyslogAppender">
+  <param name="Facility" value="LOCAL1"/>
+  <param name="SyslogHost" value="localhost:5140"/>
+  <param name="Threshold" value="INFO"/>
+  <layout class="org.apache.log4j.PatternLayout">
+    <param name="ConversionPattern"  value="%d{HH:mm:ss,SSS} %-16c %-5p - %m%n"/>
+  </layout>
+</appender>
+ -->
+ 
+ <!-- all of the loggers inherit settings from the root -->
+ <root>
+  <priority value="all" />
+  <appender-ref ref="ApplicationConsoleAppender" />
+  <!--   <appender-ref ref="syslog" /> -->
+ </root>
+
+ <!-- The file writer application logger hierachy -->
+ <logger name="FW">
+  <priority value="all" />
+  <appender-ref ref="FileWriterAppender" />
+ </logger>
+ <logger name="FW.APP"></logger>
+ <logger name="FW.SHM"></logger>
+ <logger name="FW.Frame"></logger>
+ <logger name="FW.FileWriter"></logger>
+
+</log4j:configuration>

--- a/test/integrationtest/run_integration_test.py
+++ b/test/integrationtest/run_integration_test.py
@@ -40,7 +40,7 @@ class IntegrationTest(object):
         
         rc = 0
         
-        receiver = self.launch_process("bin/frameReceiver --config %s --logconfig test_config/log4cxx.xml --debug 2 --frames %d" % 
+        receiver = self.launch_process("bin/frameReceiver --config %s --logconfig test_config/fr_log4cxx.xml --debug 2 --frames %d" % 
                                        (self.fr_config, self.frames))
         time.sleep(0.5)
         if self.use_processor:
@@ -48,7 +48,7 @@ class IntegrationTest(object):
                                             (self.fp_config, self.frames))
             writer = None
         else:
-            writer = self.launch_process("bin/filewriter --logconfig=test_config/log4cxx.xml --frames=%d --output=/tmp/integration_test.hdf5" %
+            writer = self.launch_process("bin/filewriter --logconfig=test_config/fw_log4cxx.xml --frames=%d --output=/tmp/integration_test.hdf5" %
                                          (self.frames))
             processor = None
             


### PR DESCRIPTION
Turns out that log4cxx does not work with a single configuration for muliple processes, running on the same host.
